### PR TITLE
Fix Issue #1380: Change list[str] to List[str] for dependent_task_ids in Task class

### DIFF
--- a/metagpt/schema.py
+++ b/metagpt/schema.py
@@ -338,9 +338,17 @@ class AIMessage(Message):
         super().__init__(content=content, role="assistant")
 
 
+from typing import List
+
 class Task(BaseModel):
     task_id: str = ""
-    dependent_task_ids: list[str] = []  # Tasks prerequisite to this Task
+    dependent_task_ids: List[str] = []  # Tasks prerequisite to this Task
+    instruction: str = ""
+    task_type: str = ""
+    code: str = ""
+    result: str = ""
+    is_success: bool = False
+    is_finished: bool = False
     instruction: str = ""
     task_type: str = ""
     code: str = ""


### PR DESCRIPTION
This pull request addresses issue #1380 by changing the type hint for dependent_task_ids from list[str] to List[str] in the Task class.