### PR TITLE
Fix Issue #1367: Update unpacking logic to handle 13 values returned by _get_protocol_params

### DIFF
--- a/metagpt/provider/dashscope_api.py
+++ b/metagpt/provider/dashscope_api.py
@@ -48,7 +48,7 @@ def build_api_arequest(
         request_timeout,
         form,
         resources,
-        base_address,
+( api_protocol, ws_stream_mode, is_binary_input, http_method, stream, async_request, query, headers, request_timeout, form, resources, base_address, flattened_output ) = _get_protocol_params(kwargs)
         flattened_output
     ) = _get_protocol_params(kwargs)
     task_id = kwargs.pop("task_id", None)

--- a/metagpt/provider/dashscope_api.py
+++ b/metagpt/provider/dashscope_api.py
@@ -48,7 +48,21 @@ def build_api_arequest(
         request_timeout,
         form,
         resources,
-( api_protocol, ws_stream_mode, is_binary_input, http_method, stream, async_request, query, headers, request_timeout, form, resources, base_address, flattened_output ) = _get_protocol_params(kwargs)
+(
+    api_protocol,
+    ws_stream_mode,
+    is_binary_input,
+    http_method,
+    stream,
+    async_request,
+    query,
+    headers,
+    request_timeout,
+    form,
+    resources,
+    base_address,
+    flattened_output
+) = _get_protocol_params(kwargs)
         flattened_output
     ) = _get_protocol_params(kwargs)
     task_id = kwargs.pop("task_id", None)

--- a/metagpt/provider/dashscope_api.py
+++ b/metagpt/provider/dashscope_api.py
@@ -48,6 +48,8 @@ def build_api_arequest(
         request_timeout,
         form,
         resources,
+        base_address,
+        flattened_output
     ) = _get_protocol_params(kwargs)
     task_id = kwargs.pop("task_id", None)
     if api_protocol in [ApiProtocol.HTTP, ApiProtocol.HTTPS]:


### PR DESCRIPTION
This pull request addresses issue #1367 by updating the unpacking logic in the `build_api_arequest` function to handle 13 values returned by `_get_protocol_params`.