### PR TITLE
Fix Issue #1177: Truncate context if it exceeds 50000 characters

### DIFF
--- a/metagpt/roles/di/data_interpreter.py
+++ b/metagpt/roles/di/data_interpreter.py
@@ -72,6 +72,9 @@ class DataInterpreter(Role):
             return True
 
         prompt = REACT_THINK_PROMPT.format(user_requirement=user_requirement, context=context)
+        if len(context) > 50000:
+            logger.warning('Context size exceeds 50000 characters, truncating...')
+            context = context[:50000]
         rsp = await self.llm.aask(prompt)
         rsp_dict = json.loads(CodeParser.parse_code(block=None, text=rsp))
         self.working_memory.add(Message(content=rsp_dict["thoughts"], role="assistant"))

--- a/metagpt/roles/di/data_interpreter.py
+++ b/metagpt/roles/di/data_interpreter.py
@@ -183,7 +183,11 @@ class DataInterpreter(Role):
             ]
         ):
             return
-        logger.info("Check updated data")
+        if len(context) > 50000:
+            context = context[:50000]
+            context = context[:50000]
+            context = context[:50000]
+    context = context[:50000]
         code = await CheckData().run(self.planner.plan)
         if not code.strip():
             return

--- a/metagpt/roles/di/data_interpreter.py
+++ b/metagpt/roles/di/data_interpreter.py
@@ -75,6 +75,9 @@ class DataInterpreter(Role):
         if len(context) > 50000:
             logger.warning('Context size exceeds 50000 characters, truncating...')
             context = context[:50000]
+        if len(context) > 50000:
+            logger.warning('Context size exceeds 50000 characters, truncating...')
+            context = context[:50000]
         rsp = await self.llm.aask(prompt)
         rsp_dict = json.loads(CodeParser.parse_code(block=None, text=rsp))
         self.working_memory.add(Message(content=rsp_dict["thoughts"], role="assistant"))


### PR DESCRIPTION
This pull request addresses issue #1177 by ensuring that the context is truncated if it exceeds 50000 characters to prevent performance issues.