### PR TITLE
Fix TypeError: unsupported operand type(s) for +: 'generator' and 'list' in generate_prompt_chunk function

### DIFF
--- a/metagpt/utils/text.py
+++ b/metagpt/utils/text.py
@@ -65,7 +65,7 @@ def generate_prompt_chunk(
             current_lines.append(paragraph)
             current_token += token
         elif token > max_token:
-            paragraphs = split_paragraph(paragraph) + paragraphs
+        paragraphs = list(split_paragraph(paragraph)) + paragraphs
             continue
         else:
             yield prompt_template.format("".join(current_lines))

--- a/metagpt/utils/text.py
+++ b/metagpt/utils/text.py
@@ -65,7 +65,7 @@ def generate_prompt_chunk(
             current_lines.append(paragraph)
             current_token += token
         elif token > max_token:
-        paragraphs = list(split_paragraph(paragraph)) + paragraphs
+paragraphs = list(split_paragraph(paragraph)) + paragraphs
             continue
         else:
             yield prompt_template.format("".join(current_lines))


### PR DESCRIPTION
This pull request addresses issue #737 by fixing the TypeError in the generate_prompt_chunk function.